### PR TITLE
Use a default file if it exists, otherwise fallback to nom's default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,54 @@
-npmrc-switcher
-==============
+# npmrc-switcher
 
-Application to consolidate the team-wide use of Switchable .npmrc files
+Changes the current `.npmrc` file in use.
 
+## Features
 
-##How to use
-```
-git clone git@github.com:BBC-News/npmrc-switcher.git
-cd npmrc-switcher
-npm install
-npm link
-```
+* Allows the use of a default file to fallback to.
+* Allows you to set a different npm config per project and have it commited into the project's repo.
+* Small library (~70 locs).
+* Optionally supports auto-switching.
+* Supports [bash] and [zsh].
 
-##Autoswitch
-Add this line to your `.bash_profile` or `.zshrc` or whatever it is you use.
-```
+## Anti-Features
+
+* Does not hook `cd`.
+
+## Install
+
+    git clone git@github.com:BBC-News/npmrc-switcher.git
+    cd npmrc-switcher
+    npm install
+    npm link
+
+### Auto-Switching
+
+If you want npmrc-switcher to auto-switch the current `.npmrc` file
+between your different projects. Add this line to your `.bash_profile` or `.zshrc` or whatever it is you use.
+
+``` bash
 source /path/to/npmrc-switcher/lib/auto.sh
 ```
+
+npmrc-switcher will check the current and parent directories for a `.npmrc` file.
+
+### Default npmrc
+
+If you wish to set a default npmrc file, simply create a file in your home directory called `.npmrc.default`.
+
+## Uninstall
+
+``` bash
+npm uninstall npmrc-switcher
+```
+
+If you have the autoswitcher enabled you will need to remove that line from your [bash] or [zsh] profile.
+
+
+## Credits
+
+* [Integralist](https://github.com/integralist) for reviewing the code.
+* [chruby](https://github.com/postmodern/chruby) for the idea behind this project.
+
+[bash]: http://www.gnu.org/software/bash/
+[zsh]: http://www.zsh.org/

--- a/lib/npmrc-switcher.js
+++ b/lib/npmrc-switcher.js
@@ -9,7 +9,7 @@ var shell  = require('child_process').execFile;
 var baseDirectory = process.env.HOME;
 
 var baseFile   = baseDirectory + '/.npmrc';
-var baseBackup = baseDirectory + '/.npmrc.bak';
+var defaultFile = baseDirectory + '/.npmrc.default';
 var nearestFile;
 
 function isAlreadyInUse(path) {
@@ -42,18 +42,23 @@ function copySourceToDestination(source, destination) {
     shell('/bin/cp', [source, destination]);
 }
 
-function returnToBackedUpFile() {
-    renameFile(baseBackup, baseFile);
+function defaultExists() {
+    return fs.existsSync(defaultFile);
 }
 
-function backupFileCurrentlyInUse() {
-    renameFile(baseFile, baseBackup);
+function returnToDefaultFile() {
+    if (fs.existsSync(baseFile)) {
+        fs.unlinkSync(baseFile);
+    }
+
+    if (defaultExists) {
+        renameFile(defaultFile, baseFile);
+    }
 }
 
 nearestFile = getPath();
 if (nearestFile) {
-    backupFileCurrentlyInUse();
     copySourceToDestination(nearestFile, baseFile);
 } else {
-    returnToBackedUpFile();
+    returnToDefaultFile();
 }

--- a/lib/npmrc-switcher.js
+++ b/lib/npmrc-switcher.js
@@ -52,7 +52,7 @@ function returnToDefaultFile() {
     }
 
     if (defaultExists) {
-        renameFile(defaultFile, baseFile);
+        copySourceToDestination(defaultFile, baseFile);
     }
 }
 


### PR DESCRIPTION
Another attempt at resolving issue #10 

Instead of having a `~/.npmrc.bak` file to use if no `.npmrc` is found, it will check to see if a default npmrc file exists under the name `~/.npmrc.default` and use that. If a default isn't found, it will just delete the old `~/.npmrc` file that was being used and fallback to the default settings that NPM uses (This is located wherever NPM is installed).
